### PR TITLE
switch to MeCab and fix asyncio use.

### DIFF
--- a/src/segmentize_and_lookup.py
+++ b/src/segmentize_and_lookup.py
@@ -2,7 +2,7 @@
 
 import sys
 import regex as re
-import nagisa
+import MeCab
 import requests
 import asyncio as aio
 
@@ -50,18 +50,17 @@ async def get_meaning(dictionary, word, progress_bar):
 
 async def main(meanings):
     words = set()
-
+    wakati = MeCab.Tagger('-Owakati')
     with open(sys.argv[1], 'r') as file:
         content = file.read()
-        for word in filter(
+        words = {word for word in filter(
                 validate_word,
-                nagisa.wakati(content)):
-            words.add(word)
+                wakati.parse(content).split())}
 
     print("Extracted {} words".format(len(words)))
 
     progress_bar = ProgressBar(len(words))
-    coroutines = [get_meaning(meanings, word, progress_bar) for word in words]
+    coroutines = [aio.create_task(get_meaning(meanings, word, progress_bar)) for word in words]
     await aio.wait(coroutines)
     print("\nDone.")
 


### PR DESCRIPTION
Nagisa fails to install due to issues with the DyNET build [clab/dynet#1662](https://github.com/clab/dynet/issues/1662) MeCap appears to at least do a similar job, but unfortunately I'm not able to verify against nagisa.
asyncio does not accept plain coroutines anymore, so the coroutines are being wrapped in tasks now.